### PR TITLE
Don't call async func for CPU

### DIFF
--- a/iree/turbine/runtime/op_reg/eager.py
+++ b/iree/turbine/runtime/op_reg/eager.py
@@ -100,7 +100,10 @@ def eager_dispatch(ksel: KernelSelection):
 
     # Compile.
     # TODO: We can do compilation asynchronously with the device movement
-    vm_context, vm_f, config = compile_standalone_kernel(device, ksel)
+    # TODO: Investigate issues with calling async directly on CPU. See discussion at https://github.com/iree-org/iree-turbine/pull/1110
+    vm_context, vm_f, config = compile_standalone_kernel(
+        device, ksel, async_invocations=not device.sync
+    )
 
     # Build the concrete args, issuing device movement as necessary.
     arg_list = VmVariantList(len(ksel.arg_descs))


### PR DESCRIPTION
I'm not sure why creating the hal fences externally is causing sporadic problems with the tests, but removing the async invocations for CPU seemed to resolve the issue. I'll investigate more carefully and file an upstream issue later, but lets disable and unblock.